### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/workerframework-testing-integration/pom.xml
+++ b/workerframework-testing-integration/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>workerframework-testing-integration</artifactId>
+    <name>workerframework-testing-integration</name>
 
     <dependencies>
         <dependency>

--- a/workerframework-testing-util/pom.xml
+++ b/workerframework-testing-util/pom.xml
@@ -27,6 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>workerframework-testing-util</artifactId>
+    <name>workerframework-testing-util</name>
 
 
     <dependencies>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210
